### PR TITLE
Update readme to include MacOS specific step

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ The download files is normally saved at `/out` directory of the project
 ```sh
 pip install pytube
 ```
+
+3. MacOS specific step:
+- Open your `Applications` folder in finder, and find the folder called `Python 3.x` (`x` is your python version). 
+- Double click `installcertificates.command`, which will open the terminal.


### PR DESCRIPTION
Will close #3 

I have added a macOS specific step to the readme to prevent the error caused by SSL certificate verification failing. 

I was able to test the code on a linux and windows computer also, and only the macOS computer gave this error.